### PR TITLE
Removed erroneous decrefs. Prevent const char* warning.

### DIFF
--- a/src/json.c
+++ b/src/json.c
@@ -10,7 +10,7 @@ void json_extract_measurements(char *raw_data, struct measurements *target)
     json_t *root, *results, *entry, *location, *measurements;
     json_t *measurement_line, *parameter, *date, *value;
     json_error_t error;
-    char *parameter_string;
+    const char *parameter_string;
 
     root = json_loads(raw_data, 0, &error);
     if (!json_is_object(root))
@@ -52,18 +52,10 @@ void json_extract_measurements(char *raw_data, struct measurements *target)
                 target->measurements_array[i].bc = json_real_value(value);
             else
                 printf("Unknown parameter: %s. Ignoring.\n", parameter_string);
-
-            json_decref(parameter);
-            json_decref(value);
-            json_decref(date);
         }
         target->size++;
-        json_decref(entry);
-        json_decref(location);
-        json_decref(measurements);
     }
     json_decref(root);
-    json_decref(results);
 }
 
 
@@ -88,11 +80,7 @@ void json_extract_cities(char *raw_data)
         locations = json_object_get(entry, "locations");
         printf("%d. %s: %lld location(s).\n", i + 1, 
                 json_string_value(city), json_integer_value(locations));
-        json_decref(entry);
-        json_decref(city);
-        json_decref(locations);
     }
-    json_decref(results);
     json_decref(root);
 }
 
@@ -123,10 +111,6 @@ void json_extract_locations(char *raw_data)
             json_decref(parameter);
         }
         printf("\n");
-        json_decref(entry);
-        json_decref(location);
-        json_decref(parameters);
     }
     json_decref(root);
-    json_decref(results);
 }


### PR DESCRIPTION
I was receiving random `malloc` errors at different, seemingly random, points when running your application. 

When selecting a city I would often get:
```
a.out(25380,0x113a805c0) malloc: tiny_free_list_remove_ptr: Internal invariant broken (next ptr of prev): ptr=0x7fbdd14153a0, prev_next=0x7fbdd1415390
a.out(25380,0x113a805c0) malloc: *** set a breakpoint in malloc_error_break to debug
Abort trap: 6
```
when selecting a city.

When entering country code:
```
a.out(23464,0x1100165c0) malloc: Incorrect checksum for freed object 0x7fb6b1707278: probably modified after being freed.
Corrupt value: 0xffffffffffffffff
a.out(23464,0x1100165c0) malloc: *** set a breakpoint in malloc_error_break to debug
Abort trap: 6
```

These are caused by `json_decref` calls on objects, which aren't supposed to be decref'ed. Documentation states that `json_object_get` and `json_array_get` are borrowed references, which do not increase ref count, and don't need to be decreased.