### PR TITLE
Struct typedef

### DIFF
--- a/src/api_calls.c
+++ b/src/api_calls.c
@@ -7,7 +7,7 @@
 
 int write_callback(void *input, size_t size, size_t nmemb, void *target)
 {
-    struct response_data *received = (struct response_data *)target;
+    response_data_t *received = (response_data_t *)target;
     char *ptr = realloc(received->data, received->size + nmemb + 1);
 	
 	received->data = ptr;

--- a/src/data.c
+++ b/src/data.c
@@ -4,20 +4,20 @@
 
 #include "data.h"
 
-void clear_data(struct response_data *data)
+void clear_data(response_data_t *data)
 {
     free(data->data);
     data->data = malloc(1);
     data->size = 0;
 }
 
-void init_data(struct response_data *data)
+void init_data(response_data_t *data)
 {
     data->data = malloc(1);
     data->size = 0;
 }
 
-void init_measurements(struct measurements *target)
+void init_measurements(measurements_t *target)
 {
     for (int i = 0; i < MAX_MEASUREMENTS; i++)
     {
@@ -32,7 +32,7 @@ void init_measurements(struct measurements *target)
     }
 }
 
-void print_measurements(struct measurements *source)
+void print_measurements(measurements_t *source)
 {
     for (int i = 0; i < source->size; i++)
     {

--- a/src/data.h
+++ b/src/data.h
@@ -5,13 +5,14 @@
 #define DATE_MAX 30
 #define MAX_MEASUREMENTS 100
 
-struct response_data
+struct _response_data_t
 {
     char *data;
     int size;
 };
+typedef struct _response_data_t response_data_t;
 
-struct measurement
+struct _measurement_t
 {
     char location[LOCATION_MAX];
     char date[DATE_MAX];
@@ -23,16 +24,18 @@ struct measurement
     float co;
     float bc;
 };
+typedef struct _measurement_t measurement_t;
 
-struct measurements
+struct _measurements_t
 {
-    struct measurement measurements_array[MAX_MEASUREMENTS];
+    struct _measurement_t measurements_array[MAX_MEASUREMENTS];
     int size;
 };
+typedef struct _measurements_t measurements_t;
 
-void clear_data(struct response_data *data);
-void init_data(struct response_data *data);
-void init_measurements(struct measurements *target);
-void print_measurements(struct measurements *source);
+void clear_data(response_data_t *data);
+void init_data(response_data_t *data);
+void init_measurements(measurements_t *target);
+void print_measurements(measurements_t *source);
 
 #endif

--- a/src/json.c
+++ b/src/json.c
@@ -5,7 +5,7 @@
 
 
 // extracts the JSON data from raw_data and stores the measurement data in the struct measurements *target
-void json_extract_measurements(char *raw_data, struct measurements *target)
+void json_extract_measurements(char *raw_data, measurements_t *target)
 {
     json_t *root, *results, *entry, *location, *measurements;
     json_t *measurement_line, *parameter, *date, *value;

--- a/src/json.h
+++ b/src/json.h
@@ -6,6 +6,6 @@
 
 void json_extract_cities(char *raw_data);
 void json_extract_locations(char *raw_data);
-void json_extract_measurements(char *raw_data, struct measurements *target);
+void json_extract_measurements(char *raw_data, measurements_t *target);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -8,8 +8,8 @@
 
 int main(void)
 {
-    struct response_data raw_data;
-    struct measurements measurements_data;
+    response_data_t raw_data;
+    measurements_t measurements_data;
     char city[MAX_REQUEST_SIZE];
     char country[3];
 


### PR DESCRIPTION
Feel free to reject this one as well. The general idea here is that each structure has a typedef to it, so you can create a variable like this: `measurments_t my_measurements` as opposed to `struct measurements my_measurements`.

I've added the `_t` suffix to each structure to bring a bit of consistency in type naming, so your types at least match jansson's.